### PR TITLE
Change viewport style to be more readable on 1080p screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,17 +44,12 @@ margin: 0;
 /* Entire viewport */
 section.viewport {
     display: flex;
-    width: 1024px;
-    height: 768px;
     flex-direction: column;
-    max-width: 100vw;
-    max-height: 100vh;
+    max-width: 80vw;
     margin: 0 auto;
     align-items: center;
     box-sizing: border-box;
     padding: 20px;
-    padding-bottom: 10px;
-    margin-top: max(calc((100vh - 768px) / 7), 0px);
   }
 
   /* Logo flexbox */
@@ -97,7 +92,7 @@ section.viewport {
   /* Sidebars */
   section.leftsb, section.rightsb {
     width: 190px;
-    height: 100%;
+    height: auto;
   }
 
   section.leftsb {


### PR DESCRIPTION
Updated `style.css` to remove hardcoded pixel values for the main viewport, which hindered readability on 1080p screens. The new style should respect modern screens better without scrolling content.

Will require testing (that I can't do locally because I don't know the hosting system) with the main web server before merging to ensure no undue side effects. This change is to the main viewport code, so a quick check on the main page and all sub pages should be sufficient.