### PR TITLE
Use fork of neocities CLI action to fix request failures breaking CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: ashen-dawn/neocities-upload@master
+      - uses: eritbh/neocities-upload@master
         with:
           neocities_token: ${{ secrets.NEOCITIES_API_KEY }}
           directory: '.'


### PR DESCRIPTION
See notes from https://github.com/eritbh/neocities-upload/commit/fdfd9474d95e235adbd6abda078b8c9d0cb04afc

Compare the two actions: https://github.com/ashen-dawn/neocities-upload/compare/master...eritbh:neocities-upload:master